### PR TITLE
Initialize correctly named variable: `forecast_df_folds`, not `forecast`

### DIFF
--- a/auto_ts/__init__.py
+++ b/auto_ts/__init__.py
@@ -544,7 +544,7 @@ class auto_timeseries:
             score_val = np.inf
             model_build: Optional[BuildBase] = None
             model = None
-            forecasts = None
+            forecast_df_folds = None
             print(colorful.BOLD + '\nRunning Facebook Prophet Model...' + colorful.END)
             try:
                 #### If FB prophet needs to run, it needs to be installed. Check it here ###


### PR DESCRIPTION
This PR should fix #97 (and, by extension, facebook/prophet#2392).

During the instantiation and construction of Prophet-based models in `__init__.py` ([lines ~535-577](https://github.com/AutoViML/Auto_TS/blob/master/auto_ts/__init__.py#L535-L578)), there is currently a `forecasts = None` initialization that is never used. I suspect this variable was intended to be `forecast_df_folds`, which is the variable used later for the forecasts, and matches the pattern used in the `auto_SARIMAX` model instantiation. If `forecast_df_folds` is *not* initialized to `None`, it will cause problems later on if an exception is encountered during the try/except. This change simply renames that `forecasts` variable to `forecast_df_folds` to address this.