### PR TITLE
Update packaging: add `MANIFEST.in` and `py.typed`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,29 @@
+include README.md
+include auto_ts/py.typed  # marker file for PEP 561
+
+include CHANGELOG.md
+include LICENSE
+include CITATION.cff
+include *.cff  # citation info
+
+include MANIFEST.in
+include pyproject.toml
+include setup.py
+include setup.cfg
+
+include requirements.txt
+
+recursive-exclude tests *
+recursive-exclude docs *
+recursive-exclude site *
+recursive-exclude example_datasets *
+recursive-exclude example_notebooks *
+recursive-exclude .github *
+
+exclude .flake8
+exclude .gitignore
+exclude .mypy.ini
+exclude .pre-commit-config.yaml
+exclude .pylintrc
+exclude Makefile
+exclude updates.md


### PR DESCRIPTION
This PR addresses the following two aspects of pypi-packaging. It will help also with conda-forge packaging.

- Closes #112 

### Add `MANIFEST.in` file

- this allows complete clarity and declarative specification of what to include or exclude in the packaging

:fire: NOTE: currently the following two files are missing from the `.tar.gz` aource on PyPI:

- `LICENSE` file
  > The license file is necessary for conda-forge packaging as well.
- `requirements.txt` file 
  > The setup.py file looks for the requirements.txt file and since it's not present throws an error while trying to install from the downloaded `.tar.gz` source file.

:bulb: **NO `requirements.txt` or `py.typed` FILE INCLUDED**  
<img width="740" alt="image" src="https://github.com/AutoViML/Auto_TS/assets/10201242/ead3190c-cdf7-4e5f-8f40-356841701499">


### Add `py.typed` file

This will enable support for type hinting in editors according to PEP-561.
> The `py.typed` file is supposed to be an empty file placed inside the package folder `auto_ts`.